### PR TITLE
Support Ruby 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ cache: bundler
 rvm:
   - 2.1
   - 2.6.1
+  - 3.0.0

--- a/cocoapods-disable-podfile-validations.gemspec
+++ b/cocoapods-disable-podfile-validations.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'rake', '~> 12.3'
 
-  spec.required_ruby_version = '~> 2.1'
+  spec.required_ruby_version = '>= 2.1'
 end


### PR DESCRIPTION
I was wondering if cocoapods-disable-podfile-validations could enable support for Ruby 3?

As of square/cocoapods-generate#21, the cocoapods-generate gem defines cocoapods-disable-podfile-validations as a dependency. I ran into problems when attempting to install cocoapods-generate with Ruby 3.0.0: rubygems/rubygems#4338.

I wanted to help, but I'm not very familiar with the project. This PR just amends the range for the required Ruby version in the gemspec and adds a Travis check for Ruby 3.0.0.